### PR TITLE
Fixed linting error where SQL linter could not fix it

### DIFF
--- a/models/staging/timeseries/onlinesales_lagged_features.sql
+++ b/models/staging/timeseries/onlinesales_lagged_features.sql
@@ -6,7 +6,7 @@ onlinesales as (
 
 aggregated_onlinesales as (
     select
-        created_at::date as date,
+        created_at::date as "date",
         extract(year from created_at) as year_number,
         extract(month from created_at) as month_number,
         -- Use date for daily grouping

--- a/models/staging/timeseries/onlinesales_moving_average.sql
+++ b/models/staging/timeseries/onlinesales_moving_average.sql
@@ -6,7 +6,7 @@ sales as (
 
 aggregated_sales as (
     select
-        created_at::date as date,
+        created_at::date as "date",
         extract(year from created_at) as year_number,
         extract(month from created_at) as month_number,
         -- Use date for daily grouping

--- a/models/staging/timeseries/sales_lagged_features.sql
+++ b/models/staging/timeseries/sales_lagged_features.sql
@@ -6,7 +6,7 @@ sales as (
 
 aggregated_sales as (
     select
-        created_at::date as date,
+        created_at::date as "date",
         extract(year from created_at) as year_number,
         extract(month from created_at) as month_number,
         -- Use date for daily grouping

--- a/models/staging/timeseries/sales_moving_average.sql
+++ b/models/staging/timeseries/sales_moving_average.sql
@@ -6,7 +6,7 @@ sales as (
 
 aggregated_sales as (
     select
-        created_at::date as date,
+        created_at::date as "date",
         extract(year from created_at) as year_number,
         extract(month from created_at) as month_number,
         -- Use date for daily grouping


### PR DESCRIPTION
The 4 files that could not be fixed by sqlfluff fix are onlinesales_lagged_features, onlinesales_moving_average, sales_lagged_features, and sales_moving_average.